### PR TITLE
Update datetime approach and change StartOfTestRun to StartOfScenario

### DIFF
--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
-from typing import Optional, List, Tuple, Dict
+from typing import Optional, List, Tuple, Dict, Union
 
+import arrow
 from implicitdict import ImplicitDict, StringBasedTimeDelta
 import s2sphere as s2sphere
 
@@ -427,3 +428,31 @@ class Volume4DCollection(List[Volume4D]):
 
 class Volume4DTemplateCollection(List[Volume4DTemplate]):
     pass
+
+
+def end_time_of(
+    volume_or_volumes: Union[
+        f3548v21.Volume4D,
+        Volume4D,
+        List[Union[f3548v21.Volume4D, Volume4D]],
+        Volume4DCollection,
+    ]
+) -> Optional[Time]:
+    """Retrieve the end time of a volume or list of volumes."""
+    if isinstance(volume_or_volumes, f3548v21.Volume4D):
+        if "time_end" in volume_or_volumes and volume_or_volumes.time_end:
+            return Time(volume_or_volumes.time_end.value)
+        else:
+            return None
+    elif isinstance(volume_or_volumes, Volume4D):
+        return volume_or_volumes.time_end
+    elif isinstance(volume_or_volumes, Volume4DCollection):
+        return volume_or_volumes.time_end
+    elif isinstance(volume_or_volumes, list):
+        time_ends = [end_time_of(v) for v in volume_or_volumes]
+        if not time_ends:
+            return None
+        elif any(t is None for t in time_ends):
+            return None
+        else:
+            return max(time_ends)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -275,7 +275,7 @@ class FlightIntentValidation(TestScenario):
                 {PlanningActivityResult.Failed: "Failure"},
                 self.tested_uss.client,
                 invalid_recently_ended,
-                skip_expiry_check=True,
+                may_end_in_past=True,
             )
 
             validator.expect_not_shared()

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
@@ -25,7 +25,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
@@ -24,7 +24,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 10m
 
@@ -51,7 +51,7 @@ intents:
             - start_time:
                 offset_from:
                   starting_from:
-                    time_during_test: StartOfTestRun
+                    time_during_test: StartOfScenario
                   offset: 32d
 
   invalid_recently_ended:

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
@@ -24,7 +24,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 
@@ -59,7 +59,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 


### PR DESCRIPTION
These suggestions for [650 on the interuss repo](https://github.com/interuss/monitoring/pull/650) primarily:

* Adjust the datetime comparison approach -- we don't want to mess with time zones, or generally Python's suboptimal time treatment; we can leave that to the `arrow` module we already import and use for many other similar things
* Expand and make public the function to compute an end time of volume or volumes
* Change StartOfTestRun to StartOfScenario in most test data -- I think this is the most likely thing to fix most of the problems as it decouples timing for a scenario from the rest of the scenarios in a test suite/run